### PR TITLE
opentelemetry-util-http 0.59b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-util-http" %}
-{% set version = "0.58b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: de0154896c3472c6599311c83e0ecee856c4da1b17808d39fdc5cce5312e4d89
+  sha256: ae66ee91be31938d832f3b4bc4eb8a911f6eddd38969c4a871b1230db2a0a560
 
 build:
   number: 0
@@ -16,8 +16,8 @@ build:
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - hatchling
   run:
     - python


### PR DESCRIPTION
opentelemetry-util-http 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-11283]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.59b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-util-http-feedstock
- pypi:           https://pypi.org/project/opentelemetry-util-http/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-util-http/0.59b0

### Explanation of changes:

- new version number


[PKG-11283]: https://anaconda.atlassian.net/browse/PKG-11283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ